### PR TITLE
Add data discovery API model types

### DIFF
--- a/model/dd/dataset/model.go
+++ b/model/dd/dataset/model.go
@@ -1,0 +1,12 @@
+package dataset
+
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+)
+
+// Page contains model data for a dataset page
+type Page struct {
+	model.Page
+	Dataset *dd.Dataset `json:"dataset"`
+}

--- a/model/dd/discovery.go
+++ b/model/dd/discovery.go
@@ -1,0 +1,54 @@
+package dd
+
+// Datasets represents a set of available datasets.
+type Datasets struct {
+	Items        []*Dataset `json:"items,omitempty"`
+	Count        int        `json:"count"`
+	Total        int        `json:"total"`
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+}
+
+// Dataset represents the details about a particular dataset.
+type Dataset struct {
+	ID         string       `json:"id"`
+	Title      string       `json:"title"`
+	URL        string       `json:"url,omitempty"`
+	Metadata   *Metadata    `json:"metadata,omitempty"`
+	Dimensions []*Dimension `json:"dimensions,omitempty"`
+	Data       *Table       `json:"data,omitempty"`
+}
+
+// Metadata about a dataset.
+type Metadata struct {
+	Description string   `json:"description,omitempty"`
+	Taxonomies  []string `json:"taxonomies,omitempty"`
+}
+
+// Dimension of a dataset.
+type Dimension struct {
+	ID   string `json:"id"`
+	Name string `json:"name"` // Sex
+
+	Options        []*DimensionOption `json:"options,omitempty"`
+	SelectedOption *DimensionOption   `json:"selectedOption,omitempty"`
+}
+
+// DimensionOption describes a possible value for a dimension.
+type DimensionOption struct {
+	ID   string `json:"id"`
+	Name string `json:"name"` // Male
+
+	Options []*DimensionOption `json:"options,omitempty"`
+}
+
+// Row is a particular data point in a dataset.
+type Row struct {
+	Observation interface{}        // 123
+	Dimensions  []*DimensionOption // Sex=Male
+}
+
+// Table is a set of rows in a dataset.
+type Table struct {
+	Rows []*Row
+}

--- a/model/dd/homepage/model.go
+++ b/model/dd/homepage/model.go
@@ -1,8 +1,12 @@
 package homepage
 
-import "github.com/ONSdigital/dp-frontend-models/model"
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+)
 
 // Homepage contains model data for the Data Discovery homepage
 type Homepage struct {
 	model.Page
+	Datasets *dd.Datasets `json:"datasets"`
 }


### PR DESCRIPTION
### What

Pull the model types from the dp-dd-api-stub into the common models project so that they can be used by the front-end controller and renderer.

### How to review

Inspection - see related reviews against the controller and renderer for more detailed testing.

### Who can review

Anyone but me.
