### PR TITLE
Add 'Unit of measurement' to CMD preview

### DIFF
--- a/model/dataset-filter/previewPage/preview-page.go
+++ b/model/dataset-filter/previewPage/preview-page.go
@@ -22,6 +22,7 @@ type PreviewPage struct {
 	DatasetID             string        `json:"dataset_id"`
 	Edition               string        `json:"edition"`
 	ReleaseDate           string        `json:"release_date"`
+	UnitOfMeasurement     string        `json:"unit_of_measurement"`
 	SingleValueDimensions []Dimension   `json:"single_value_dimensions"`
 	FilterOutputID        string        `json:"filter_output_id"`
 }


### PR DESCRIPTION
### What

https://trello.com/c/sqMAzb7G/3083-add-unit-of-measurement-to-cmd-preview

added .Data.UnitOfMeasurement to template 
https://github.com/ONSdigital/dp-frontend-renderer/pull/210

p.Data.UnitOfMeasurement to mapper
https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/111

json:"unit_of_measurement" in PreviewPage struct

### How to review

https://beta.ons.gov.uk/filter-outputs/32112ac0-6f68-4efc-b03c-083aa5436534
and a filter-outputs page with no unit of measurement

### Who can review

jon or crispin
