### PR TITLE
Added ServiceName to the metadata

### DIFF
--- a/model/metadata.go
+++ b/model/metadata.go
@@ -4,5 +4,6 @@ package model
 type Metadata struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
+	ServiceName string   `json:"serviceName"`
 	Keywords    []string `json:"keywords"`
 }


### PR DESCRIPTION
### What

dp-frontend-renderer requires the service name. This is part of improving error page identification. 
ServiceName added to the metadata.

### How to review

1. Checkout the dp-frontend-renderer branch 'feature/meta-service-name' locally
2. Run the renderer without other services 
3. Inspect the page (Developer console) and check the Meta tags in the page Head. 
4. The following should be present `<meta name="ons:service" content="dp-frontend-renderer">`

### Who can review

A member of the team that is able to run the 'dp-frontend-renderer'
