### PR TITLE
Added latestVersionURL to filterable landing page

### DIFF
--- a/model/datasetLandingPageFilterable/model.go
+++ b/model/datasetLandingPageFilterable/model.go
@@ -19,6 +19,7 @@ type DatasetLandingPage struct {
 	Edition             string        `json:"edition"`
 	ReleaseFrequency    string        `json:"release_frequency"`
 	IsLatest            bool          `json:"is_latest"`
+	LatestVersionURL    string        `json:"latest_version_url"`
 	QMIURL              string        `json:"qmi_url"`
 	IsNationalStatistic bool          `json:"is_national_statistic"`
 	Publications        []Publication `json:"publications"`


### PR DESCRIPTION
### What

Latest release alert should appear on all editions

### How to review

- Check out the following branches from the below PRs:
    - https://github.com/ONSdigital/dp-frontend-renderer/pull/280
    - https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/102
- Load the latest edition you should see a blue banner saying this is the latest data
- Load an edition that isn't the latest, you should see an amber banner stating it is not the latest.
- Check out the links to ensure they work.

Note I am not 100% sure this has been done for the correct pages, as it states the latest edition, but it is the latest version of the addition.

Please compare this with the prototype: 
https://onsdigital.github.io/dp-filter-a-dataset-prototype/v2/editions . Note that corrections are not being added to the alert and that the alert is the only item to be changed.

### Who can review

Anyone except me
