### PR TITLE
Updated reasons for version page to be an array

### DIFF
--- a/model/datasetVersionsList/model.go
+++ b/model/datasetVersionsList/model.go
@@ -17,7 +17,7 @@ type VersionsList struct {
 // Version represents an edition version on the version list page
 type Version struct {
 	Date      string     `json:"date"`
-	Reason    string     `json:"reason"`
+	Reasons   []string   `json:"reasons"`
 	Downloads []Download `json:"downloads"`
 	FilterURL string     `json:"filter_url"`
 }


### PR DESCRIPTION
### What

Added wrap to versions page correction list

### How to review

Checkout the following related PR branches:
sixteens - https://github.com/ONSdigital/sixteens/pull/156
dp-frontend-renderer - https://github.com/ONSdigital/dp-frontend-renderer/pull/286
dp-frontend-dataset-controller - https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/103

Check out the versions page of an edition

### Who can review

Anyone except me