### PR TITLE
Added IsLatestVersionOfEdition property to datasetlandingpage model

### DIFF
--- a/model/datasetLandingPageFilterable/model.go
+++ b/model/datasetLandingPageFilterable/model.go
@@ -13,23 +13,24 @@ type Page struct {
 
 type DatasetLandingPage struct {
 	datasetLandingPageStatic.DatasetLandingPage
-	Dimensions          []Dimension   `json:"dimensions"`
-	Version             Version       `json:"version"`
-	HasOlderVersions    bool          `json:"has_older_versions"`
-	ShowEditionName     bool          `json:"show_edition_name"`
-	Edition             string        `json:"edition"`
-	ReleaseFrequency    string        `json:"release_frequency"`
-	IsLatest            bool          `json:"is_latest"`
-	LatestVersionURL    string        `json:"latest_version_url"`
-	QMIURL              string        `json:"qmi_url"`
-	IsNationalStatistic bool          `json:"is_national_statistic"`
-	Publications        []Publication `json:"publications"`
-	RelatedLinks        []Publication `json:"related_links"`
-	LatestChanges       []Change      `json:"latest_changes"`
-	Citation            string        `json:"citation"`
-	DatasetTitle        string        `json:"dataset_title"`
-	UnitOfMeasurement   string        `json:"unit_of_measurement"`
-	Methodologies       []Methodology `json:"methodology"`
+	Dimensions               []Dimension   `json:"dimensions"`
+	Version                  Version       `json:"version"`
+	HasOlderVersions         bool          `json:"has_older_versions"`
+	ShowEditionName          bool          `json:"show_edition_name"`
+	Edition                  string        `json:"edition"`
+	ReleaseFrequency         string        `json:"release_frequency"`
+	IsLatest                 bool          `json:"is_latest"`
+	LatestVersionURL         string        `json:"latest_version_url"`
+	IsLatestVersionOfEdition bool          `json:"is_latest_version_of_edition_url"`
+	QMIURL                   string        `json:"qmi_url"`
+	IsNationalStatistic      bool          `json:"is_national_statistic"`
+	Publications             []Publication `json:"publications"`
+	RelatedLinks             []Publication `json:"related_links"`
+	LatestChanges            []Change      `json:"latest_changes"`
+	Citation                 string        `json:"citation"`
+	DatasetTitle             string        `json:"dataset_title"`
+	UnitOfMeasurement        string        `json:"unit_of_measurement"`
+	Methodologies            []Methodology `json:"methodology"`
 }
 
 type Publication struct {


### PR DESCRIPTION
### What

Fix for banner appearing on dataset landing pages:
- Goes to the web page rather than the API when you click ‘previous’
- Clicking previous now goes to the correct version (not the latest version of published that uses the dataset (different edition)
- Correctly shows previous and latest version banner (was previously showing ‘this is not the latest’ when it was if there was a version of a different edition of that dataset published.

### How to review

Dependencies:
dp-frontend-dataset-controller: https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/116
dp-frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/293

1. Get a dataset, make an edition, make a version of the edition
2. Get the same dataset and the same edition, make a new version
3. Get the same dataset, make a new edition and create a version of that edition
4. Goto step 2 version and check the banner shows 'this is the latest' banner and the link is correct
5. Goto step 1 and check this shows 'this is not the latest' banner click link ensure it goes to the correct version of the correct edition

### Who can review

Anyone except me
