### PR TITLE
Feature/beta banner enabled

### DIFF
--- a/model/page.go
+++ b/model/page.go
@@ -19,4 +19,5 @@ type Page struct {
 	IncludeAssetsIntegrityAttributes bool           `json:"-"`
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
+	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
 }


### PR DESCRIPTION
### What

The beta banner now selectively displayed
It should appear on the following types of pages 

- version
- versions list
- edition
- filter journey pages:
  -  Age
  -  Time
  -  Hierarchy
  -  Hierarchy Search
  -  Preview
  -  ListSelector
  -  Filter Overview

### How to review

Checkout the following PRs:
dp-frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/296
dp-frontend-dataset-controller: https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/118
dp-frontend-filter-dataset-controller: https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/160

Run the CMD stack
Checkout different types of pages, ensure that the Beta banner only appears on CMD pages

### Who can review

Anyone except me
