### PR TITLE
Added CurrentVersionURL field to previewPage model

### DIFF
--- a/model/dataset-filter/previewPage/preview-page.go
+++ b/model/dataset-filter/previewPage/preview-page.go
@@ -19,6 +19,7 @@ type PreviewPage struct {
 	Dimensions            []Dimension   `json:"dimensions"`
 	IsLatestVersion       bool          `json:"is_latest_version"`
 	LatestVersion         LatestVersion `json:"latest_version"`
+	CurrentVersionURL     string        `json:"current_version_url"`
 	DatasetTitle          string        `json:"dataset_title"`
 	DatasetID             string        `json:"dataset_id"`
 	Edition               string        `json:"edition"`


### PR DESCRIPTION
### What

Added a `CurrentVersionURL` string field to the preview page model - users can now return to the dataset landing page of the current version they're viewing rather than the most recent version.

### How to review

Sanity check of the model?

### Who can review

Anyone