### PR TITLE
removed loop11 from page model

### DIFF
--- a/model/page.go
+++ b/model/page.go
@@ -19,7 +19,6 @@ type Page struct {
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
 	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
-	EnableLoop11                     bool           `json:"enable_loop11"`
 	EnableCookiesControl             bool           `json:"enable_cookies_control"`
 	CookiesPreferencesSet            bool           `json:"cookies_preferences_set"`
 	CookiesPolicy                    CookiesPolicy  `json:"cookies_policy"`


### PR DESCRIPTION
### What

- Removed loop11  from the page model as this will no longer be used on the site.

### How to review

Check that it's removed 

### Who can review

Anyone but me
