### PR TITLE
Add JSONLd flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ONSdigital/dp-frontend-models
+
+go 1.13

--- a/model/page.go
+++ b/model/page.go
@@ -22,4 +22,6 @@ type Page struct {
 	EnableCookiesControl             bool           `json:"enable_cookies_control"`
 	CookiesPreferencesSet            bool           `json:"cookies_preferences_set"`
 	CookiesPolicy                    CookiesPolicy  `json:"cookies_policy"`
+	EnableJSONLdControl              bool           `json:"enable_jsonld_control"`
+	HasJSONLd                        bool           `json:"has_jsonld"`
 }

--- a/model/page.go
+++ b/model/page.go
@@ -22,6 +22,6 @@ type Page struct {
 	EnableCookiesControl             bool           `json:"enable_cookies_control"`
 	CookiesPreferencesSet            bool           `json:"cookies_preferences_set"`
 	CookiesPolicy                    CookiesPolicy  `json:"cookies_policy"`
-	EnableJSONLdControl              bool           `json:"enable_jsonld_control"`
-	HasJSONLd                        bool           `json:"has_jsonld"`
+	EnableJSONLDControl              bool           `json:"enable_jsonld_control"`
+	HasJSONLD                        bool           `json:"has_jsonld"`
 }


### PR DESCRIPTION
### What

- Updated Page model to include `JSONLd` feature flag and `HasJsonLd` feature. The latter is used to conditionally render the json-ld script based on whether or not the page needs it.
- Initialised go modules

### How to review

- Check json-ld changes make sense
- Check go modules initialisation - I'm assuming the `go mod init` command didn't create a `go.sum` file because there are no modules included in the library. It would be good to get confirmation if that is the case though

### Who can review

Anyone but me
