### PR TITLE
add search data model

### DIFF
--- a/model/search/search.go
+++ b/model/search/search.go
@@ -1,0 +1,83 @@
+package search
+
+import "github.com/ONSdigital/dp-frontend-models/model"
+
+// Page ...
+type Page struct {
+	model.Page
+	Data Search `json:"data"`
+}
+
+// Search ..
+type Search struct {
+	Query    string   `json:"query"`
+	Filter   []string `json:"filter,omitempty"`
+	Sort     string   `json:"sort,omitempty"`
+	Limit    int      `json:"limit,omitempty"`
+	Offset   int      `json:"offset,omitempty"`
+	Response Response `json:"response"`
+}
+
+// Response ...
+type Response struct {
+	Count        int           `json:"count"`
+	ContentTypes []contentType `json:"content_types"`
+	Items        []contentItem `json:"items"`
+	Suggestions  []string      `json:"suggestions,omitempty"`
+}
+
+type contentType struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
+}
+
+type contentItem struct {
+	Description description `json:"description"`
+	Type        string      `json:"type"`
+	URI         string      `json:"uri"`
+	Matches     *matches    `json:"matches,omitempty"`
+}
+
+type description struct {
+	Contact           *contact  `json:"contact,omitempty"`
+	DatasetID         string    `json:"dataset_id,omitempty"`
+	Edition           string    `json:"edition,omitempty"`
+	Headline1         string    `json:"headline1,omitempty"`
+	Headline2         string    `json:"headline2,omitempty"`
+	Headline3         string    `json:"headline3,omitempty"`
+	Keywords          *[]string `json:"keywords,omitempty"`
+	LatestRelease     *bool     `json:"latest_release,omitempty"`
+	Language          string    `json:"language,omitempty"`
+	MetaDescription   string    `json:"meta_description,omitempty"`
+	NationalStatistic *bool     `json:"national_statistic,omitempty"`
+	NextRelease       string    `json:"next_release,omitempty"`
+	PreUnit           string    `json:"pre_unit,omitempty"`
+	ReleaseDate       string    `json:"release_date,omitempty"`
+	Source            string    `json:"source,omitempty"`
+	Summary           string    `json:"summary"`
+	Title             string    `json:"title"`
+	Unit              string    `json:"unit,omitempty"`
+}
+
+type contact struct {
+	Name      string `json:"name"`
+	Telephone string `json:"telephone,omitempty"`
+	Email     string `json:"email"`
+}
+
+type matches struct {
+	Description struct {
+		Summary         *[]matchDetails `json:"summary"`
+		Title           *[]matchDetails `json:"title"`
+		Edition         *[]matchDetails `json:"edition,omitempty"`
+		MetaDescription *[]matchDetails `json:"meta_description,omitempty"`
+		Keywords        *[]matchDetails `json:"keywords,omitempty"`
+		DatasetID       *[]matchDetails `json:"dataset_id,omitempty"`
+	} `json:"description"`
+}
+
+type matchDetails struct {
+	Value string `json:"value,omitempty"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+}


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
Add `search` data model

The model is comprised of a page struct which contains default `model.Page` and `data`
where the data would include:

- input data - which are the `query`, `filter` search result (based on content type), `sort` result, `limit` number of results on page, `offset` (the first row of resources to retrieve, starting at 0. Would use this as a pagination mechanism along with the limit parameter)

- output data (`Response`) - which would output the search results
This is an example of what the expected outcome should be https://github.com/ONSdigital/dp-search-query/blob/develop/transformer/testdata/search_expected.json

### How to review

**Describe the steps required to test the changes.**
Check if the code makes sense

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes