### PR TITLE
split matches description struct

### DIFF
--- a/model/search/search.go
+++ b/model/search/search.go
@@ -66,14 +66,16 @@ type Contact struct {
 }
 
 type Matches struct {
-	Description struct {
-		Summary         *[]MatchDetails `json:"summary"`
-		Title           *[]MatchDetails `json:"title"`
-		Edition         *[]MatchDetails `json:"edition,omitempty"`
-		MetaDescription *[]MatchDetails `json:"meta_description,omitempty"`
-		Keywords        *[]MatchDetails `json:"keywords,omitempty"`
-		DatasetID       *[]MatchDetails `json:"dataset_id,omitempty"`
-	} `json:"description"`
+	Description MatchDescription `json:"description"`
+}
+
+type MatchDescription struct {
+	Summary         *[]MatchDetails `json:"summary"`
+	Title           *[]MatchDetails `json:"title"`
+	Edition         *[]MatchDetails `json:"edition,omitempty"`
+	MetaDescription *[]MatchDetails `json:"meta_description,omitempty"`
+	Keywords        *[]MatchDetails `json:"keywords,omitempty"`
+	DatasetID       *[]MatchDetails `json:"dataset_id,omitempty"`
 }
 
 type MatchDetails struct {


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
Separate the internal `Description` struct in the `Matches` struct to enable easier mapping in the `dp-frontend-search-controller` whilst maintaining the structure of the model

### How to review

**Describe the steps required to test the changes.**
Check if the code makes sense

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes