### PR TITLE
add bool properties for setting up homepage graceful degradation

### DIFF
--- a/model/homepage/model.go
+++ b/model/homepage/model.go
@@ -12,12 +12,12 @@ type Page struct {
 
 //Homepage contains data specific to this page type
 type Homepage struct {
-	MainFigures           map[string]*MainFigure `json:"main_figures"`
-	NoMainFigures         bool                   `json:"no_main_figures"`
-	ReleaseCalendar       ReleaseCalendar        `json:"release_calendar"`
-	Featured              []Feature              `json:"featured"`
-	FeaturedContentLoaded bool                   `json:"featured_content_loaded"`
-	AroundONS             []Feature              `json:"arounds_ons"`
+	MainFigures        map[string]*MainFigure `json:"main_figures"`
+	HasMainFigures     bool                   `json:"has_main_figures"`
+	ReleaseCalendar    ReleaseCalendar        `json:"release_calendar"`
+	Featured           []Feature              `json:"featured"`
+	HasFeaturedContent bool                   `json:"has_featured_content"`
+	AroundONS          []Feature              `json:"arounds_ons"`
 }
 
 //ReleaseCalendar is data for release calendar block

--- a/model/homepage/model.go
+++ b/model/homepage/model.go
@@ -12,10 +12,12 @@ type Page struct {
 
 //Homepage contains data specific to this page type
 type Homepage struct {
-	MainFigures     map[string]*MainFigure `json:"main_figures"`
-	ReleaseCalendar ReleaseCalendar        `json:"release_calendar"`
-	Featured        []Feature              `json:"featured"`
-	AroundONS       []Feature              `json:"arounds_ons"`
+	MainFigures           map[string]*MainFigure `json:"main_figures"`
+	NoMainFigures         bool                   `json:"no_main_figures"`
+	ReleaseCalendar       ReleaseCalendar        `json:"release_calendar"`
+	Featured              []Feature              `json:"featured"`
+	FeaturedContentLoaded bool                   `json:"featured_content_loaded"`
+	AroundONS             []Feature              `json:"arounds_ons"`
 }
 
 //ReleaseCalendar is data for release calendar block


### PR DESCRIPTION
### What

Added two new properties to the homepage model: `NoMainFigures` and `FeaturedContentLoaded`. These are to determine whether or not graceful degradation states should be rendered when building the homepage in the renderer

If no main figures could be loaded, a single tile replaces all of the main figures tiles on the homepage to inform the user that the content could not be loaded

If the featured content wasn't loaded, then the section is removed entirely (as such, `FeaturedContentLoaded`, if `true`, will be used to render the In Focus partial)

### How to review

Sense check changes and logic

### Who can review

Anyone
