### PR TITLE
Homepage show trend added

### DIFF
--- a/model/homepage/model.go
+++ b/model/homepage/model.go
@@ -42,6 +42,7 @@ type MainFigure struct {
 	Date             string     `json:"date"`
 	Figure           string     `json:"figure"`
 	Trend            Trend      `json:"trend"`
+	ShowTrend        bool       `json:"show_trend"`
 	TrendDescription string     `json:"trend_description"`
 	Unit             string     `json:"unit"`
 	FigureURIs       FigureURIs `json:"figure_uris"`


### PR DESCRIPTION
### What

- Now there is a timeseries available for trend PP differences we can use trend indicators on homepage for employment and unemployment
- Auditing updated, along with dependencies
Important note, those that have a dedicated timeseires for trend indication should not show any trend information if that timeseries fails to load.

With trend indicators back in this is what it looks like:
![Screenshot 2021-02-02 at 10 04 37](https://user-images.githubusercontent.com/47502916/106584655-59913b80-653e-11eb-933f-1ab8ab1d1d36.png)


### How to review

1. Pull the  [dp-frontend-models PR](https://github.com/ONSdigital/dp-frontend-models/pull/80)
2. Pull the [dp-frontend-hompage-controller PR](https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/51)
3. Pull the [dp-frontend-renderer PR](https://github.com/ONSdigital/dp-frontend-renderer/pull/562)
4. In dp-frontend-homepage-controller run 
```bash 
go mod edit --replace github.com/ONSdigital/dp-frontend-models=/{ absolute path to your local dp-frontend-models }/dp-frontend-models
```
5. In dp-frontend-renderer run
```bash 
go mod edit --replace github.com/ONSdigital/dp-frontend-models=/{ absolute path to your local dp-frontend-models }/dp-frontend-models
```
6. First test case, go to the homepage locally you should see the main figures tiles looking like how they currently do on https://www.ons.gov.uk/ (employment and unemployment have no trend indicators).
7. Make a new local directory for first new content in your local Zebedee content directory, if your $zebedee_root is setup you should be able to run the following
```bash
mkdir -p $zebedee_root/zebedee/master/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/FUX7/lms
```
8. Navigate to this new directory and make a new file `data.json`, if using the command line you can just run
```bash
touch data.json
```
9. Copy the raw text content from [https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/FUX7/lms/data](https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/FUX7/lms/data
)
10. Paste this text content into the data.json created in step 8.
11. We will now repeat this process and add a second content file. Make a new local directory for the new content in your local Zebedee content directory, if your $zebedee_root is setup you should be able to run the following 
```bash
mkdir -p $zebedee_root/zebedee/master/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/fuu8/lms
```
12. Navigate to this new directory and make a new file `data.json`, if using the command line you can just run
```bash
touch data.json
```
13. Copy the raw text content from [https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/fuu8/lms/data](https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/fuu8/lms/data
), yes you may have noticed that for whatever reason the unemployment timeseries is under 'peopleinwork' rather than 'peoplenotinwork'...
14. Paste this text content into the data.json created in step 12.
15. Navigate back to your local homepage in a browser, you should now see trend indicators matching the latest data in those two data.json files copied.

### Who can review

Anyone except me
