### PR TITLE
add page fields for search

### DIFF
--- a/model/search/search.go
+++ b/model/search/search.go
@@ -10,12 +10,12 @@ type Page struct {
 
 // Search represents all search parameters and response data of the search
 type Search struct {
-	Query    string   `json:"query"`
-	Filter   []string `json:"filter,omitempty"`
-	Sort     Sort     `json:"sort,omitempty"`
-	Limit    Limit    `json:"limit,omitempty"`
-	Offset   Offset   `json:"offset,omitempty"`
-	Response Response `json:"response"`
+	Query      string     `json:"query"`
+	Filter     []string   `json:"filter,omitempty"`
+	Sort       Sort       `json:"sort,omitempty"`
+	Limit      Limit      `json:"limit,omitempty"`
+	Pagination Pagination `json:"offset,omitempty"`
+	Response   Response   `json:"response"`
 }
 
 // Sort represents all the information of sorting related to the search page

--- a/model/search/search.go
+++ b/model/search/search.go
@@ -13,7 +13,7 @@ type Search struct {
 	Query      string     `json:"query"`
 	Filter     []string   `json:"filter,omitempty"`
 	Sort       Sort       `json:"sort,omitempty"`
-	Pagination Pagination `json:"offset,omitempty"`
+	Pagination Pagination `json:"pagination,omitempty"`
 	Response   Response   `json:"response"`
 }
 

--- a/model/search/search.go
+++ b/model/search/search.go
@@ -38,8 +38,8 @@ type Limit struct {
 	Options []int `json:"options,omitempty"`
 }
 
-// Offset represents
-type Offset struct {
+// Pagination represents all information regarding pagination of search results
+type Pagination struct {
 	Page           int    `json:"page,omitempty"`
 	TotalPages     int    `json:"total_pages,omitempty"`
 	URLWithoutPage string `json:"url_without_page,omitempty"`

--- a/model/search/search.go
+++ b/model/search/search.go
@@ -11,17 +11,11 @@ type Page struct {
 // Search represents all search parameters and response data of the search
 type Search struct {
 	Query    string   `json:"query"`
-	Filter   Filter   `json:"filter,omitempty"`
+	Filter   []string `json:"filter,omitempty"`
 	Sort     Sort     `json:"sort,omitempty"`
-	Limit    int      `json:"limit,omitempty"`
-	Offset   int      `json:"offset,omitempty"`
+	Limit    Limit    `json:"limit,omitempty"`
+	Offset   Offset   `json:"offset,omitempty"`
 	Response Response `json:"response"`
-}
-
-// Filter represents all the information of filter related to the search page
-type Filter struct {
-	Query   []string `json:"query,omitempty"`
-	Options []string `json:"options,omitempty"`
 }
 
 // Sort represents all the information of sorting related to the search page
@@ -36,6 +30,19 @@ type Sort struct {
 type SortOptions struct {
 	Query           string `json:"query,omitempty"`
 	LocaliseKeyName string `json:"localise_key"`
+}
+
+// Limit represents the number of results to be shown in one page and all the possible limit options
+type Limit struct {
+	Query   int   `json:"query,omitempty"`
+	Options []int `json:"options,omitempty"`
+}
+
+// Offset represents
+type Offset struct {
+	Page           int    `json:"page,omitempty"`
+	TotalPages     int    `json:"total_pages,omitempty"`
+	URLWithoutPage string `json:"url_without_page,omitempty"`
 }
 
 // Response represents the search results

--- a/model/search/search.go
+++ b/model/search/search.go
@@ -13,7 +13,6 @@ type Search struct {
 	Query      string     `json:"query"`
 	Filter     []string   `json:"filter,omitempty"`
 	Sort       Sort       `json:"sort,omitempty"`
-	Limit      Limit      `json:"limit,omitempty"`
 	Pagination Pagination `json:"offset,omitempty"`
 	Response   Response   `json:"response"`
 }
@@ -32,17 +31,13 @@ type SortOptions struct {
 	LocaliseKeyName string `json:"localise_key"`
 }
 
-// Limit represents the number of results to be shown in one page and all the possible limit options
-type Limit struct {
-	Query   int   `json:"query,omitempty"`
-	Options []int `json:"options,omitempty"`
-}
-
 // Pagination represents all information regarding pagination of search results
 type Pagination struct {
 	Page           int    `json:"page,omitempty"`
 	TotalPages     int    `json:"total_pages,omitempty"`
 	URLWithoutPage string `json:"url_without_page,omitempty"`
+	Limit          int    `json:"limit,omitempty"`
+	LimitOptions   []int  `json:"limit_options,omitempty"`
 }
 
 // Response represents the search results


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Removed `FilterOptions` as this is already controlled in the `Categories` struct
- Add `Pagination` struct which now includes the fields `Page`, `TotalPages` and `URLWithoutPage` which provides information for pagination for search results
- Add `Limit` and  the additional `LimitOptions` field to which gives information about all possible limits to the number of results to be displayed on the website to the renderer

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone - Justin made the changes