### PR TITLE
feature/extract pagination from search package and move to model

### DIFF
--- a/model/dataset-filter/listSelector/list-selector.go
+++ b/model/dataset-filter/listSelector/list-selector.go
@@ -5,8 +5,9 @@ import "github.com/ONSdigital/dp-frontend-models/model"
 // Page ...
 type Page struct {
 	model.Page
-	Data     ListSelector `json:"data"`
-	FilterID string       `json:"job_id"`
+	Pagination model.Pagination `json:"pagination,omitempty"`
+	Data       ListSelector     `json:"data"`
+	FilterID   string           `json:"job_id"`
 }
 
 // ListSelector ..

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -1,0 +1,10 @@
+package model
+
+// Pagination represents all information regarding pagination of search results
+type Pagination struct {
+	CurrentPage    int    `json:"page,omitempty"`
+	TotalPages     int    `json:"total_pages,omitempty"`
+	URLWithoutPage string `json:"url_without_page,omitempty"`
+	Limit          int    `json:"limit,omitempty"`
+	LimitOptions   []int  `json:"limit_options,omitempty"`
+}

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -2,7 +2,7 @@ package model
 
 // Pagination represents all information regarding pagination of search results
 type Pagination struct {
-	CurrentPage    int    `json:"page,omitempty"`
+	CurrentPage    int    `json:"current_page,omitempty"`
 	TotalPages     int    `json:"total_pages,omitempty"`
 	URLWithoutPage string `json:"url_without_page,omitempty"`
 	Limit          int    `json:"limit,omitempty"`

--- a/model/search/search.go
+++ b/model/search/search.go
@@ -10,11 +10,11 @@ type Page struct {
 
 // Search represents all search parameters and response data of the search
 type Search struct {
-	Query      string     `json:"query"`
-	Filter     []string   `json:"filter,omitempty"`
-	Sort       Sort       `json:"sort,omitempty"`
-	Pagination Pagination `json:"pagination,omitempty"`
-	Response   Response   `json:"response"`
+	Query      string           `json:"query"`
+	Filter     []string         `json:"filter,omitempty"`
+	Sort       Sort             `json:"sort,omitempty"`
+	Pagination model.Pagination `json:"pagination,omitempty"`
+	Response   Response         `json:"response"`
 }
 
 // Sort represents all the information of sorting related to the search page
@@ -29,15 +29,6 @@ type Sort struct {
 type SortOptions struct {
 	Query           string `json:"query,omitempty"`
 	LocaliseKeyName string `json:"localise_key"`
-}
-
-// Pagination represents all information regarding pagination of search results
-type Pagination struct {
-	Page           int    `json:"page,omitempty"`
-	TotalPages     int    `json:"total_pages,omitempty"`
-	URLWithoutPage string `json:"url_without_page,omitempty"`
-	Limit          int    `json:"limit,omitempty"`
-	LimitOptions   []int  `json:"limit_options,omitempty"`
 }
 
 // Response represents the search results


### PR DESCRIPTION
### What

- Extracted the `Pagination` struct from the `search` package and moved into the generic `model` package. This is because the pagination pattern being used in Search will also be used in the CMD filter journey in due course.
- Updated `search.go` and `list-selector.go` to make use of the Pagination struct in its page model

### How to review

Sense check the changes

### Who can review

Anyone
