### PR TITLE
add pagination pages

### DIFF
--- a/model/pagination.go
+++ b/model/pagination.go
@@ -2,10 +2,16 @@ package model
 
 // Pagination represents all information regarding pagination of search results
 type Pagination struct {
-	CurrentPage    int    `json:"current_page,omitempty"`
-	Pages          []int  `json:"pages,omitempty"`
-	TotalPages     int    `json:"total_pages,omitempty"`
-	URLWithoutPage string `json:"url_without_page,omitempty"`
-	Limit          int    `json:"limit,omitempty"`
-	LimitOptions   []int  `json:"limit_options,omitempty"`
+	CurrentPage    int             `json:"current_page"`
+	PagesToDisplay []PageToDisplay `json:"pages_to_display"`
+	TotalPages     int             `json:"total_pages"`
+	URLWithoutPage string          `json:"url_without_page"`
+	Limit          int             `json:"limit"`
+	LimitOptions   []int           `json:"limit_options,omitempty"`
+}
+
+// PageToDisplay represents a page to display in pagination with their corresponding URL
+type PageToDisplay struct {
+	Page int    `json:"page"`
+	URL  string `json:"url"`
 }

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -3,6 +3,7 @@ package model
 // Pagination represents all information regarding pagination of search results
 type Pagination struct {
 	CurrentPage    int    `json:"current_page,omitempty"`
+	Pages          []int  `json:"pages,omitempty"`
 	TotalPages     int    `json:"total_pages,omitempty"`
 	URLWithoutPage string `json:"url_without_page,omitempty"`
 	Limit          int    `json:"limit,omitempty"`

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -12,6 +12,6 @@ type Pagination struct {
 
 // PageToDisplay represents a page to display in pagination with their corresponding URL
 type PageToDisplay struct {
-	Page int    `json:"page"`
-	URL  string `json:"url"`
+	PageNumber int    `json:"page_number"`
+	URL        string `json:"url"`
 }


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Add `Pages` in the `Pagination` struct which is a list of pages such as [3,4,**5**,6,7] if I am on page 5. With this list, the renderer can loop through these pages to make a link to each page in the pagination area of the page. Without this list, the renderer needs to do some logic to create this list which would be ideal to avoid.   

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense 

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes